### PR TITLE
feat: add endpoint and services loan atribute update

### DIFF
--- a/src/main/java/com/bichotas/moduloprestamos/controller/PrestamoController.java
+++ b/src/main/java/com/bichotas/moduloprestamos/controller/PrestamoController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 
 @RestController
@@ -346,4 +348,52 @@ public class PrestamoController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.singletonMap("error", e.getMessage()));
         }
     }
+
+
+    @PutMapping("/update-{id}")
+    @Operation(
+            summary = "Actualizar un atributo del préstamo",
+            description = "Actualiza un atributo específico del préstamo, excepto si el préstamo está en estado de vencido o devuelto",
+            tags = {"Prestamos"},
+            parameters = {
+                    @io.swagger.v3.oas.annotations.Parameter(
+                            name = "id",
+                            description = "ID del préstamo a actualizar",
+                            required = true,
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(type = "string")
+                    )
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "Préstamo actualizado correctamente"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "Solicitud incorrecta"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "Préstamo no encontrado"
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "500",
+                            description = "Error interno del servidor"
+                    )
+            }
+    )
+
+    public ResponseEntity<?> updatePrestamo(@PathVariable String id, @RequestBody Map<String, Object> updates) {
+        try {
+            prestamoService.updatePrestamo(id, updates);
+            return ResponseEntity.status(HttpStatus.OK).body(Collections.singletonMap("message", "Prestamo actualizado correctamente"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.singletonMap("error", e.getMessage()));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.singletonMap("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.singletonMap("error", e.getMessage()));
+        }
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a new feature to update specific attributes of a loan (`Prestamo`). It includes changes to both the controller and service layers to support this functionality. Additionally, some minor formatting changes were made to the service layer.

### New Feature: Update Loan Attributes

* **Controller Layer:**
  * Added new `updatePrestamo` method in `PrestamoController` to handle PUT requests for updating loan attributes. This method includes detailed Swagger documentation for API consumers.

* **Service Layer:**
  * Introduced `updatePrestamo` method in `PrestamoService` to perform the actual update of loan attributes, including validation and error handling.

### Minor Changes

* **Imports:**
  * Added necessary imports in both `PrestamoController` and `PrestamoService` for handling updates and exceptions. [[1]](diffhunk://#diff-d099ac6828340a07d0ad5c95c524a7ca703a125b337ddd89f5bd50b4eb5b175cR15-R16) [[2]](diffhunk://#diff-adca893a2187ceb27c6c9d9c5397cdf6ff57a1f67ef0a61f813f16ce3e7ab56aR5-R9)

* **Formatting:**
  * Added missing JavaDoc comments in `PrestamoService` for better code documentation and readability. [[1]](diffhunk://#diff-adca893a2187ceb27c6c9d9c5397cdf6ff57a1f67ef0a61f813f16ce3e7ab56aR149) [[2]](diffhunk://#diff-adca893a2187ceb27c6c9d9c5397cdf6ff57a1f67ef0a61f813f16ce3e7ab56aR167) [[3]](diffhunk://#diff-adca893a2187ceb27c6c9d9c5397cdf6ff57a1f67ef0a61f813f16ce3e7ab56aR185)