### PR TITLE
Release 1.0.1

### DIFF
--- a/src/main/java/com/bichotas/moduloprestamos/config/CorsConfig.java
+++ b/src/main/java/com/bichotas/moduloprestamos/config/CorsConfig.java
@@ -13,8 +13,8 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 public class CorsConfig {
     
-    @Value("${FRONTEND_URL}")
-    private String frontendUrl;
+
+    private String frontendUrl = "*";
 
     @Bean
     public CorsFilter corsFilter() {


### PR DESCRIPTION
This pull request includes a small change to the `CorsConfig` class in the `src/main/java/com/bichotas/moduloprestamos/config` directory. The change sets a default value for the `frontendUrl` variable to allow all origins by default.

* [`src/main/java/com/bichotas/moduloprestamos/config/CorsConfig.java`](diffhunk://#diff-ab37391167f67344d11b71ad2104fb0f21715b003ae83f25da7a387cd735a19dL16-R17): Changed the `frontendUrl` variable from being populated by a property value to a default value of `"*"` to allow all origins.