### PR TITLE
Test/update loan

### DIFF
--- a/src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java
+++ b/src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java
@@ -136,4 +136,53 @@ class PrestamoControllerTest {
         assertEquals(404, response.getStatusCodeValue());
         assertEquals(Collections.singletonMap("error", "Prestamo not found"), response.getBody());
     }
+
+
+    @Test
+    void shouldUpdatePrestamoSuccessfully() {
+        Map<String, Object> updates = Map.of("estado", "Devuelto");
+
+        doNothing().when(prestamoService).updatePrestamo("1", updates);
+
+        ResponseEntity<?> response = prestamoController.updatePrestamo("1", updates);
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("message", "Prestamo actualizado correctamente"), response.getBody());
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidUpdate() {
+        Map<String, Object> updates = Map.of("estado", "Devuelto");
+
+        doThrow(new IllegalArgumentException("Invalid update")).when(prestamoService).updatePrestamo("1", updates);
+
+        ResponseEntity<?> response = prestamoController.updatePrestamo("1", updates);
+
+        assertEquals(400, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("error", "Invalid update"), response.getBody());
+    }
+
+    @Test
+    void shouldReturnNotFoundForNonExistentPrestamo() {
+        Map<String, Object> updates = Map.of("estado", "Devuelto");
+
+        doThrow(new NoSuchElementException("Prestamo not found")).when(prestamoService).updatePrestamo("1", updates);
+
+        ResponseEntity<?> response = prestamoController.updatePrestamo("1", updates);
+
+        assertEquals(404, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("error", "Prestamo not found"), response.getBody());
+    }
+
+    @Test
+    void shouldReturnInternalServerErrorForUnexpectedException() {
+        Map<String, Object> updates = Map.of("estado", "Devuelto");
+
+        doThrow(new RuntimeException("Unexpected error")).when(prestamoService).updatePrestamo("1", updates);
+
+        ResponseEntity<?> response = prestamoController.updatePrestamo("1", updates);
+
+        assertEquals(500, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("error", "Unexpected error"), response.getBody());
+    }
 }

--- a/src/test/java/com/bichotas/moduloprestamos/service/PrestamoServiceTest.java
+++ b/src/test/java/com/bichotas/moduloprestamos/service/PrestamoServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,7 +109,7 @@ class PrestamoServiceTest {
     }
 
     @Test
-    public void shouldGetPrestamos(){
+    public void shouldGetPrestamos() {
         Prestamo prestamo1 = new Prestamo();
         prestamo1.setIdEstudiante("123");
         prestamo1.setIdLibro("456");
@@ -271,5 +272,93 @@ class PrestamoServiceTest {
         });
     }
 
+    @Test
+    public void shouldUpdateObservacionesSuccessfully() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        prestamoService.updatePrestamo("123", Map.of("observaciones", "New observation"));
+
+        assertEquals("New observation", prestamo.getObservaciones());
+        verify(prestamoRepository, times(1)).save(prestamo);
+    }
+
+    @Test
+    public void shouldUpdateEstadoSuccessfully() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        prestamoService.updatePrestamo("123", Map.of("estado", "Devuelto"));
+
+        assertEquals("Devuelto", prestamo.getEstado());
+        verify(prestamoRepository, times(1)).save(prestamo);
+    }
+
+    @Test
+    public void shouldUpdateFechaDevolucionSuccessfullyWithString() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        prestamoService.updatePrestamo("123", Map.of("fecha_devolucion", "2023-10-10T10:10:10"));
+
+        assertEquals(LocalDate.of(2023, 10, 10), prestamo.getFechaDevolucion());
+        verify(prestamoRepository, times(1)).save(prestamo);
+    }
+
+    @Test
+    public void shouldUpdateFechaDevolucionSuccessfullyWithLocalDateTime() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        prestamoService.updatePrestamo("123", Map.of("fecha_devolucion", LocalDateTime.of(2023, 10, 10, 10, 10, 10)));
+
+        assertEquals(LocalDate.of(2023, 10, 10), prestamo.getFechaDevolucion());
+        verify(prestamoRepository, times(1)).save(prestamo);
+    }
+
+    @Test
+    public void shouldThrowExceptionForInvalidFechaDevolucionFormat() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            prestamoService.updatePrestamo("123", Map.of("fecha_devolucion", 12345));
+        });
+    }
+
+    @Test
+    public void shouldUpdateHistorialEstadoSuccessfully() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        prestamoService.updatePrestamo("123", Map.of("historial_estado", "New history"));
+
+        assertEquals("New history", prestamo.getHistorialEstado());
+        verify(prestamoRepository, times(1)).save(prestamo);
+    }
+
+    @Test
+    public void shouldThrowExceptionForInvalidAttribute() {
+        Prestamo prestamo = new Prestamo();
+        prestamo.setEstado("Prestado");
+
+        when(prestamoRepository.findById(any(String.class))).thenReturn(java.util.Optional.of(prestamo));
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            prestamoService.updatePrestamo("123", Map.of("invalid_attribute", "value"));
+        });
+    }
 
 }


### PR DESCRIPTION
This pull request adds new tests to the `PrestamoControllerTest` and `PrestamoServiceTest` classes to improve the coverage and robustness of the update functionality for the `Prestamo` entity. 

### New Tests for `PrestamoControllerTest`:
* Added a test to verify successful update of a `Prestamo` (`shouldUpdatePrestamoSuccessfully`).
* Added a test to handle invalid update requests (`shouldReturnBadRequestForInvalidUpdate`).
* Added a test to handle updates for non-existent `Prestamo` entities (`shouldReturnNotFoundForNonExistentPrestamo`).
* Added a test to handle unexpected exceptions during update (`shouldReturnInternalServerErrorForUnexpectedException`).

### New Tests for `PrestamoServiceTest`:
* Added a test to verify successful update of the `observaciones` attribute (`shouldUpdateObservacionesSuccessfully`).
* Added a test to verify successful update of the `estado` attribute (`shouldUpdateEstadoSuccessfully`).
* Added tests to verify successful update of `fecha_devolucion` with both `String` and `LocalDateTime` formats (`shouldUpdateFechaDevolucionSuccessfullyWithString`, `shouldUpdateFechaDevolucionSuccessfullyWithLocalDateTime`).
* Added a test to handle invalid format for `fecha_devolucion` (`shouldThrowExceptionForInvalidFechaDevolucionFormat`).
* Added a test to verify successful update of the `historial_estado` attribute (`shouldUpdateHistorialEstadoSuccessfully`).
* Added a test to handle invalid attributes during update (`shouldThrowExceptionForInvalidAttribute`).