### PR TITLE
add controller tests

### DIFF
--- a/src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java
+++ b/src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java
@@ -136,4 +136,37 @@ class PrestamoControllerTest {
         assertEquals(404, response.getStatusCodeValue());
         assertEquals(Collections.singletonMap("error", "Prestamo not found"), response.getBody());
     }
+
+
+
+    @Test
+    void shouldReturnEmptyListWhenNoPrestamosForEstudiante() {
+        when(prestamoService.getPrestamosByIdEstudiante("123")).thenReturn(Collections.emptyList());
+
+        ResponseEntity<?> response = prestamoController.getPrestamosByEstudiante("123");
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("prestamos", Collections.emptyList()), response.getBody());
+    }
+
+    @Test
+    void shouldReturnServerErrorWhenExceptionOccurs() {
+        when(prestamoService.getPrestamosByIdEstudiante("123")).thenThrow(new RuntimeException("Unexpected error"));
+
+        ResponseEntity<?> response = prestamoController.getPrestamosByEstudiante("123");
+
+        assertEquals(500, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("error", "Unexpected error"), response.getBody());
+    }
+
+
+    @Test
+    void shouldReturnServerErrorWhenUnexpectedExceptionOccurs() {
+        doThrow(new RuntimeException("Unexpected error")).when(prestamoService).deletePrestamoById("1");
+
+        ResponseEntity<?> response = prestamoController.deletePrestamo("1");
+
+        assertEquals(500, response.getStatusCodeValue());
+        assertEquals(Collections.singletonMap("error", "Unexpected error"), response.getBody());
+    }
 }


### PR DESCRIPTION
This pull request includes several enhancements to the `PrestamoControllerTest` class to improve test coverage and error handling. The most important changes include adding new test cases to handle different scenarios such as no prestamos found for a student and handling exceptions.

Enhancements to test coverage:

* [`src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java`](diffhunk://#diff-d481a0898264096aa883cad0e964e74008d4e34204a0090f4f328a9ce85e08e7R139-R171): Added a test case to verify that an empty list is returned when no prestamos are found for a given student ID.
* [`src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java`](diffhunk://#diff-d481a0898264096aa883cad0e964e74008d4e34204a0090f4f328a9ce85e08e7R139-R171): Added a test case to verify that a server error is returned when an exception occurs while fetching prestamos by student ID.
* [`src/test/java/com/bichotas/moduloprestamos/controller/PrestamoControllerTest.java`](diffhunk://#diff-d481a0898264096aa883cad0e964e74008d4e34204a0090f4f328a9ce85e08e7R139-R171): Added a test case to verify that a server error is returned when an unexpected exception occurs during the deletion of a prestamo.