### PR TITLE
fix/update controller a workflow

### DIFF
--- a/.github/workflows/main_modulo-prestamos.yml
+++ b/.github/workflows/main_modulo-prestamos.yml
@@ -37,6 +37,20 @@ jobs:
           name: java-app
           path: '${{ github.workspace }}/target/*.jar'
 
+  test:
+    runs-on: ubuntu-latest
+    needs: build  # Este job depende de que se haya ejecutado build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run tests (verify phase)
+        run: mvn verify
+
   deploy:
     runs-on: windows-latest
     needs: build

--- a/src/main/java/com/bichotas/moduloprestamos/controller/PrestamoController.java
+++ b/src/main/java/com/bichotas/moduloprestamos/controller/PrestamoController.java
@@ -233,7 +233,11 @@ public class PrestamoController {
             }
     )
     public ResponseEntity<?> getPrestamos(@RequestParam(value = "estado", required = false) String estado) {
-        return ResponseEntity.status(HttpStatus.OK).body(Collections.singletonMap("prestamos", prestamoService.getPrestamos(estado)));
+        try {
+            return ResponseEntity.status(HttpStatus.OK).body(Collections.singletonMap("prestamos", prestamoService.getPrestamos(estado)));
+        } catch (PrestamosException.PrestamosExceptionStateError e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.singletonMap("error", e.getMessage()));
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request includes several important changes to the workflow configuration and the `PrestamoController` class. The changes improve the CI/CD pipeline by adding a test job and enhance error handling in the controller.

Improvements to CI/CD pipeline:

* [`.github/workflows/main_modulo-prestamos.yml`](diffhunk://#diff-580d31bcafd848906296fd7bdfcd102bcf41efc5ef9a7783f9788f758a5cc9f6R40-R53): Added a new `test` job that runs on `ubuntu-latest`, depends on the `build` job, sets up JDK 21, and runs Maven verify phase to execute tests.

Enhancements to error handling:

* [`src/main/java/com/bichotas/moduloprestamos/controller/PrestamoController.java`](diffhunk://#diff-d099ac6828340a07d0ad5c95c524a7ca703a125b337ddd89f5bd50b4eb5b175cR236-R240): Wrapped the `getPrestamos` method in a try-catch block to handle `PrestamosException.PrestamosExceptionStateError` and return a `BAD_REQUEST` status with an error message if an exception occurs.